### PR TITLE
Add the ability to get time off types, request time off, change it's status + some refactoring

### DIFF
--- a/lib/employee.js
+++ b/lib/employee.js
@@ -1,6 +1,7 @@
 var util = require('util'),
     xml2js = require('xml2js'),
-    utilities = require('./utilities')
+    utilities = require('./utilities'),
+    TimeOffRequest = require('./time-off-request')
 
 //-- Employee Class
 
@@ -153,6 +154,13 @@ Employee.prototype.customTable = function () {
     //var args = Array.prototype.slice.call(arguments, 0)
     //args.unshift('contacts')
     return this.__table_handler.apply(this, args)
+}
+
+Employee.prototype.requestTimeOff = function (data, callback) {
+    data = util._extend({ employeeId: this.id }, data)
+    var request = new TimeOffRequest(this.parent, data)
+    request.add(callback)
+    return request
 }
 
 module.exports = Employee

--- a/lib/employee.js
+++ b/lib/employee.js
@@ -1,0 +1,158 @@
+var util = require('util'),
+    xml2js = require('xml2js'),
+    utilities = require('./utilities')
+
+//-- Employee Class
+
+function Employee(parent) {
+    var args = Array.prototype.slice.call(arguments, 1)
+    this.parent = parent
+
+    var fields = args.pop()
+    if (fields instanceof Object) {
+        this.fields = fields
+        this.id = args[0] || null
+    }
+    else {
+        this.id = fields
+        this.fields = {}
+    }
+}
+
+Employee.prototype.__parse_fields = function (fields) {
+    for (var i in fields) {
+        this.fields[fields[i].$.id] = fields[i]._
+    }
+}
+
+Employee.prototype.__to_xml = function () {
+    var f = { employee: utilities.buildFields(this.fields) }
+    return (new xml2js.Builder()).buildObject(f)
+}
+
+Employee.prototype.get = function () {
+    var options
+    var args = Array.prototype.slice.call(arguments, 0)
+    var callback = args.pop()
+
+    options = args.length ? { fields: args.join(',') } : {}
+
+    var self = this
+    this.parent.__get('employees/' + (this.id || 0), options, function (err, response) {
+        if (err) { return callback(err) }
+
+        var emp = new Employee(self.parent);
+        emp.__parse_fields(response.employee.field)
+        emp.id = response.employee.$.id
+        if (callback) callback(err, emp)
+    })
+}
+
+Employee.prototype.update = function (callback) {
+    this.parent.__post('employees/' + this.id, null, this.__to_xml(), callback)
+}
+
+Employee.prototype.add = function (callback) {
+    var self = this
+
+    this.parent.__post('employees/', null, this.__to_xml(), function (err, response) {
+        if (err) { return callback(err) }
+
+        var id = /employees\/(\d+)/.exec(response)[1]
+        self.id = id
+        callback(null, self)
+    })
+}
+
+// Just a utility function for bamboohr.requests({employeeId: this.id})
+Employee.prototype.requests = function () {
+    var args = Array.prototype.slice.call(arguments, 0)
+    var callback = args.pop()
+
+    var options = util._extend({employeeId: this.id}, args[0] || {})
+
+    self = this
+    this.parent.requests(options, function (err, response) {
+        if (err) { return callback(err) }
+
+        for (var req in response) {
+            // Set parent to this object
+        }
+
+        callback(null, response);
+    })
+}
+
+Employee.prototype.estimates = function(end, callback) {
+    end = utilities.formatDate(end)
+
+    this.parent.__get('employees/' + this.id + '/time_off/calculator/', {end: end}, function (err, resp) {
+        if (err) { return callback(err) }
+        callback(null, resp.estimates.estimate)
+    })
+}
+
+Employee.prototype.__table_handler = function () {
+    var args = Array.prototype.slice.call(arguments, 0)
+    var table = args.shift()
+    var callback = args.pop()
+
+    // getter
+    if (args.length === 0) {
+        this.parent.__get('employees/' + this.id + '/tables/' + table + '/', null, function (err, resp) {
+            if (err) { return callback(err) }
+            callback(null, resp.table.row)
+        })
+    }
+    else {
+        var rowdata = args.pop()
+        var f = { row : utilities.buildFields(rowdata) }
+        var xml = (new xml2js.Builder()).buildObject(f)
+
+        if (args.length) {
+            var rowid = args[0]
+            this.parent.__post('employees/' + this.id + '/tables/' + table + '/' + rowid, null, xml, callback)
+        }
+        else {
+            this.parent.__post('employees/' + this.id + '/tables/' + table, null, xml, callback)
+        }
+    }
+}
+
+Employee.prototype.jobInfo = function () {
+    var args = Array.prototype.slice.call(arguments, 0)
+    args.unshift('jobInfo')
+    return this.__table_handler.apply(this, args)
+}
+
+Employee.prototype.employmentStatus = function () {
+    var args = Array.prototype.slice.call(arguments, 0)
+    args.unshift('employmentStatus')
+    return this.__table_handler.apply(this, args)
+}
+
+Employee.prototype.compensation = function () {
+    var args = Array.prototype.slice.call(arguments, 0)
+    args.unshift('compensation')
+    return this.__table_handler.apply(this, args)
+}
+
+Employee.prototype.dependents = function () {
+    var args = Array.prototype.slice.call(arguments, 0)
+    args.unshift('dependents')
+    return this.__table_handler.apply(this, args)
+}
+
+Employee.prototype.contacts = function () {
+    var args = Array.prototype.slice.call(arguments, 0)
+    args.unshift('contacts')
+    return this.__table_handler.apply(this, args)
+}
+
+Employee.prototype.customTable = function () {
+    //var args = Array.prototype.slice.call(arguments, 0)
+    //args.unshift('contacts')
+    return this.__table_handler.apply(this, args)
+}
+
+module.exports = Employee

--- a/lib/index.js
+++ b/lib/index.js
@@ -38,7 +38,7 @@ function BambooHR(options) {
           password: 'x'
         },
         headers: {
-            'User-Agent': 'node-bamboohr/' + require('./package.json').version + ' (node/' + process.version + ')'
+            'User-Agent': 'node-bamboohr/' + require('../package.json').version + ' (node/' + process.version + ')'
         }
     })
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -43,9 +43,12 @@ BambooHR.prototype.__request = function (method, uri, options, data, callback) {
         }
 
         if (body) {
-            xml2js.parseString(body, callback)
-        }
-        else {
+            if (options && options.json) {
+                callback(null, body)
+            } else {
+                xml2js.parseString(body, callback)
+            }
+        } else {
             callback(null, null)
         }
     })
@@ -57,15 +60,21 @@ BambooHR.prototype.__post = function (uri, options, data, callback) {
     })
 }
 
-BambooHR.prototype.__get = function (uri, options, callback) {
-    var qs = options ? { qs: options } : {}
-    this.__request('get', uri, qs, null, callback)
+BambooHR.prototype.__get = function (uri, qs, options, callback) {
+    if (typeof options === 'function') {
+        callback = options
+        options = {}
+    }
+    options = options || {}
+    if (qs) {
+        options.qs = qs
+    }
+    this.__request('get', uri, options, null, callback)
 }
 
 BambooHR.prototype.employee = function () {
     var args = Array.prototype.slice.call(arguments, 0)
     var fields = args.pop()
-
     if (fields instanceof Object) {
         return new Employee(this, args[0] || null, fields)
     }
@@ -97,7 +106,7 @@ BambooHR.prototype.timeOffRequests = BambooHR.prototype.requests = function () {
     var self = this;
 
     this.__get('time_off/requests/', opts, function (err, response) {
-        if (err) { return callback(err) }
+        if (err) { return callback(err, response) }
         var requests = response.requests.request
 
         var list = requests.map(function (object) {
@@ -121,6 +130,12 @@ BambooHR.prototype.whosOut = function (start, end, callback) {
     this.__get('time_off/whos_out', {
         start: start,
         end: end
+    }, callback)
+}
+
+BambooHR.prototype.timeOffTypes = function (callback) {
+    this.__get('meta/time_off/types/', null, {
+        json: true
     }, callback)
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,32 +1,9 @@
 var request = require('request'),
     xml2js = require('xml2js'),
-    util = require('util')
+    util = require('util'),
+    Employee = require('./employee'),
+    utilities = require('./utilities')
 
-/* UTILITY FUNCTIONS */
-function __Date_Helper(date) {
-    /* if it's a Date, translate to appropriate format, otherwise assume we are
-     * passing in the correct format
-     */
-
-    if (date instanceof Date) {
-        return date.getFullYear() + '-' + (date.getMonth() < 9 ? '0' : '') + (date.getMonth() + 1) + '-' + (date.getDate() < 10 ? '0' :'') + date.getDate()
-    }
-    else {
-        return date
-    }
-}
-
-function __Field_Builder(fields) {
-    var f = []
-    for (var i in fields) {
-        f.push({
-            $: { id: i },
-            _: fields[i] || ''
-        })
-    }
-
-    return { field: f }
-}
 
 /* CLASSES */
 
@@ -127,166 +104,13 @@ BambooHR.prototype.requests = function () {
 }
 
 BambooHR.prototype.whosOut = function (start, end, callback) {
-    start = __Date_Helper(start)
-    end = __Date_Helper(end)
+    start = utilities.formatDate(start)
+    end = utilities.formatDate(end)
 
     this.__get('time_off/whos_out', {
         start: start,
         end: end
     }, callback)
-}
-
-//-- Employee Class
-
-function Employee(parent) {
-    var args = Array.prototype.slice.call(arguments, 1)
-    this.parent = parent
-
-    var fields = args.pop()
-    if (fields instanceof Object) {
-        this.fields = fields
-        this.id = args[0] || null
-    }
-    else {
-        this.id = fields
-        this.fields = {}
-    }
-}
-
-Employee.prototype.__parse_fields = function (fields) {
-    for (var i in fields) {
-        this.fields[fields[i].$.id] = fields[i]._
-    }
-}
-
-Employee.prototype.__to_xml = function () {
-    var f = { employee: __Field_Builder(this.fields) }
-    return (new xml2js.Builder()).buildObject(f)
-}
-
-Employee.prototype.get = function () {
-    var options
-    var args = Array.prototype.slice.call(arguments, 0)
-    var callback = args.pop()
-
-    options = args.length ? { fields: args.join(',') } : {}
-
-    var self = this
-    this.parent.__get('employees/' + (this.id || 0), options, function (err, response) {
-        if (err) { return callback(err) }
-
-        var emp = new Employee(self.parent);
-        emp.__parse_fields(response.employee.field)
-        emp.id = response.employee.$.id
-        if (callback) callback(err, emp)
-    })
-}
-
-Employee.prototype.update = function (callback) {
-    this.parent.__post('employees/' + this.id, null, this.__to_xml(), callback)
-}
-
-Employee.prototype.add = function (callback) {
-    var self = this
-
-    this.parent.__post('employees/', null, this.__to_xml(), function (err, response) {
-        if (err) { return callback(err) }
-
-        var id = /employees\/(\d+)/.exec(response)[1]
-        self.id = id
-        callback(null, self)
-    })
-}
-
-// Just a utility function for bamboohr.requests({employeeId: this.id})
-Employee.prototype.requests = function () {
-    var args = Array.prototype.slice.call(arguments, 0)
-    var callback = args.pop()
-
-    var options = util._extend({employeeId: this.id}, args[0] || {})
-
-    self = this
-    this.parent.requests(options, function (err, response) {
-        if (err) { return callback(err) }
-
-        for (var req in response) {
-            // Set parent to this object
-        }
-
-        callback(null, response);
-    })
-}
-
-Employee.prototype.estimates = function(end, callback) {
-    end = __Date_Helper(end)
-
-    this.parent.__get('employees/' + this.id + '/time_off/calculator/', {end: end}, function (err, resp) {
-        if (err) { return callback(err) }
-        callback(null, resp.estimates.estimate)
-    })
-}
-
-Employee.prototype.__table_handler = function () {
-    var args = Array.prototype.slice.call(arguments, 0)
-    var table = args.shift()
-    var callback = args.pop()
-
-    // getter
-    if (args.length === 0) {
-        this.parent.__get('employees/' + this.id + '/tables/' + table + '/', null, function (err, resp) {
-            if (err) { return callback(err) }
-            callback(null, resp.table.row)
-        })
-    }
-    else {
-        var rowdata = args.pop()
-        var f = { row : __Field_Builder(rowdata) }
-        var xml = (new xml2js.Builder()).buildObject(f)
-
-        if (args.length) {
-            var rowid = args[0]
-            this.parent.__post('employees/' + this.id + '/tables/' + table + '/' + rowid, null, xml, callback)
-        }
-        else {
-            this.parent.__post('employees/' + this.id + '/tables/' + table, null, xml, callback)
-        }
-    }
-}
-
-Employee.prototype.jobInfo = function () {
-    var args = Array.prototype.slice.call(arguments, 0)
-    args.unshift('jobInfo')
-    return this.__table_handler.apply(this, args)
-}
-
-Employee.prototype.employmentStatus = function () {
-    var args = Array.prototype.slice.call(arguments, 0)
-    args.unshift('employmentStatus')
-    return this.__table_handler.apply(this, args)
-}
-
-Employee.prototype.compensation = function () {
-    var args = Array.prototype.slice.call(arguments, 0)
-    args.unshift('compensation')
-    return this.__table_handler.apply(this, args)
-}
-
-Employee.prototype.dependents = function () {
-    var args = Array.prototype.slice.call(arguments, 0)
-    args.unshift('dependents')
-    return this.__table_handler.apply(this, args)
-}
-
-Employee.prototype.contacts = function () {
-    var args = Array.prototype.slice.call(arguments, 0)
-    args.unshift('contacts')
-    return this.__table_handler.apply(this, args)
-}
-
-Employee.prototype.customTable = function () {
-    //var args = Array.prototype.slice.call(arguments, 0)
-    //args.unshift('contacts')
-    return this.__table_handler.apply(this, args)
 }
 
 module.exports = BambooHR

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,8 +2,8 @@ var request = require('request'),
     xml2js = require('xml2js'),
     util = require('util'),
     Employee = require('./employee'),
+    TimeOffRequest = require('./time-off-request'),
     utilities = require('./utilities')
-
 
 /* CLASSES */
 
@@ -21,6 +21,9 @@ function BambooHR(options) {
 }
 
 BambooHR.prototype.__request = function (method, uri, options, data, callback) {
+    if (data instanceof Object) {
+        data = (new xml2js.Builder()).buildObject(data)
+    }
     this.request(util._extend({
         method: method,
         url: 'https://api.bamboohr.com/api/gateway.php/' + this.options.subdomain + '/v1/' + uri,
@@ -87,20 +90,28 @@ BambooHR.prototype.employees = function (callback) {
     })
 }
 
-BambooHR.prototype.requests = function () {
+BambooHR.prototype.timeOffRequests = BambooHR.prototype.requests = function () {
     var args = Array.prototype.slice.call(arguments, 0)
     var callback = args.pop()
     var opts = args[0] || {}
+    var self = this;
 
     this.__get('time_off/requests/', opts, function (err, response) {
         if (err) { return callback(err) }
         var requests = response.requests.request
-        return callback(null, requests)
 
-        for (var i in requests) {
-            // Create a timeoffrequest with a new employee() linked
-        }
+        var list = requests.map(function (object) {
+            var request = new TimeOffRequest(self, object.$.id)
+            request.__parse_fields(object)
+            return request
+        })
+
+        return callback(null, list)
     })
+}
+
+BambooHR.prototype.timeOffRequest = function (id, fields) {
+    return new TimeOffRequest(this, id, fields)
 }
 
 BambooHR.prototype.whosOut = function (start, end, callback) {

--- a/lib/time-off-request.js
+++ b/lib/time-off-request.js
@@ -1,0 +1,109 @@
+var utilities = require('./utilities')
+
+var allowedFields = ['employeeId', 'status', 'start', 'end', 'timeOffTypeId', 'amount', 'notes', 'dates', 'previousRequest']
+
+function TimeOffRequest(parent, id, fields) {
+    if (id instanceof Object) {
+        fields = id
+        id = null
+    }
+    fields = fields || {}
+
+    this.parent = parent
+    this.id = id
+    var self = this
+
+    allowedFields.forEach(function (field) {
+        if (field in fields) {
+            self[field] = fields[field]
+        }
+    })
+
+    formatDates(self)
+}
+
+function formatDates(self) {
+    // Just to make sure everything is consistent
+    self.start = utilities.formatDate(self.start)
+    self.end = utilities.formatDate(self.end)
+    if (self.dates) {
+        self.dates.forEach(function (obj) {
+            obj.date = utilities.formatDate(obj.date)
+        })
+    }
+}
+
+TimeOffRequest.prototype.__parse_fields = function (object) {
+    this.employeeId = object.employee[0].$.id
+    this.employeeName = object.employee[0]._
+    this.status = object.status[0]._
+    this.statusLastChanged = object.status[0].$.lastChanged
+    this.statusLastChangedByUserId = object.status[0].$.lastChangedByUserId
+    this.start = object.start[0]
+    this.end = object.end[0]
+    this.created = object.created[0]
+    this.type = object.type[0]._
+    this.typeId = object.type[0].$.id
+    this.amount = object.amount[0]._
+    this.amountUnit = object.amount[0].$.unit
+    var notes = object.notes && object.notes[0].note;
+    this.notes = notes && notes.map(function (note) {
+        return {
+            from: note.$.from,
+            note: note._
+        }
+    }) || []
+    var dates = object.dates && object.dates[0].date;
+    this.dates = dates && dates.map(function (date) {
+        return {
+            date: date.$.ymd,
+            amount: date.$.amount
+        }
+    })
+}
+
+TimeOffRequest.prototype.add = function (callback) {
+    formatDates(this)
+
+    var data = {
+        status: this.status,
+        start: this.start,
+        end: this.end,
+        timeOffTypeId: this.timeOffTypeId,
+        amount: this.amount,
+        previousRequest: this.previousRequest
+    }
+
+    if (this.notes) {
+        data.notes = {
+            note: this.notes.map(function (note) {
+                return {
+                    $: { from: note.from },
+                    _: note.note
+                }
+            })
+        }
+    }
+
+    if (this.dates) {
+        data.dates = {
+            date: this.dates.map(function (date) {
+                return { $: {
+                    amount: date.amount,
+                    ymd: date.date
+                }}
+            })
+        }
+    }
+
+    this.parent.__request('put', 'employees/' + this.employeeId + '/time_off/request/', null,
+        { request: data }, callback);
+}
+
+TimeOffRequest.prototype.changeStatus = function (data, callback) {
+    this.parent.__request('put', 'time_off/requests/' + this.id + '/status/', null, {
+        request: data
+    }, callback);
+}
+
+module.exports = TimeOffRequest

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -1,0 +1,25 @@
+/* UTILITY FUNCTIONS */
+exports.formatDate = function (date) {
+    /* if it's a Date, translate to appropriate format, otherwise assume we are
+     * passing in the correct format
+     */
+
+    if (date instanceof Date) {
+        return date.getFullYear() + '-' + (date.getMonth() < 9 ? '0' : '') + (date.getMonth() + 1) + '-' + (date.getDate() < 10 ? '0' :'') + date.getDate()
+    }
+    else {
+        return date
+    }
+}
+
+exports.buildFields = function (fields) {
+    var f = []
+    for (var i in fields) {
+        f.push({
+            $: { id: i },
+            _: fields[i] || ''
+        })
+    }
+
+    return { field: f }
+}

--- a/package.json
+++ b/package.json
@@ -22,5 +22,6 @@
     },
     "scripts": {
         "test": "./node_modules/mocha/bin/mocha"
-    }
+    },
+    "main": "lib/index.js"
 }

--- a/test/test.js
+++ b/test/test.js
@@ -320,4 +320,46 @@ suite('BambooHR', function () {
             scope.done()
         })
     })
+
+
+    suite('Metadata', function () {
+        var scope;
+        var body = {
+            timeOffTypes: [{
+                id: '1',
+                name: 'Vacation',
+                units: 'hours',
+                color: 'eef448',
+                icon: 'palm-trees'
+            }],
+            defaultHours: [
+                { name: 'Saturday', amount: '0' },
+                { name: 'Sunday', amount: '0' },
+                { name: 'default', amount: '8' }
+            ]
+        };
+
+        suiteSetup(function() {
+            scope = nock('https://api.bamboohr.com', {
+                reqheaders: {
+                    authorization: 'Basic MTIzOng=',
+                    Accept: 'application/json'
+                }
+            })
+                .get('/api/gateway.php/test/v1/meta/time_off/types/')
+                .reply(200, body)
+        })
+
+
+        test('We should get a list of time off types', function (done) {
+            bamboo.timeOffTypes(function (err, res) {
+                assert.deepEqual(res, body);
+                done(err);
+            })
+        })
+
+        suiteTeardown(function() {
+            scope.done()
+        })
+    })
 })

--- a/test/test.js
+++ b/test/test.js
@@ -3,6 +3,7 @@ var BambooHR = require('../lib/index')
 var nock = require('nock')
 nock.disableNetConnect();
 
+var xml2js = require('xml2js')
 var assert = require('assert')
 
 suite('BambooHR', function () {
@@ -231,14 +232,45 @@ suite('BambooHR', function () {
                 .reply(200, '<requests><request id="1"><employee id="1">Jon Doe</employee><status lastChanged="2011-08-14" lastChangedByUserId="1">approved</status><start>2001-01-01</start><end>2001-01-06</end><created>2011-08-13</created><type id="1">Vacation</type><amount unit="days">5</amount><notes><note from="employee">Relaxing in the country for a few days.</note><note from="manager">Have fun!</note></notes><dates> <!-- This element may not be available for all requests --><date ymd="2001-01-01" amount="1"/><date ymd="2001-01-02" amount="1"/><date ymd="2001-01-03" amount="1"/><!-- dates with a 0 amount may not be included in the results. Included here for clarity --><date ymd="2001-01-04" amount="0"/> <date ymd="2001-01-05" amount="1"/><date ymd="2001-01-06" amount="1"/></dates></request></requests>')
                 .get('/api/gateway.php/test/v1/time_off/requests/?start=2011-09-01&end=2011-09-11&type=1&status=approved')
                 .reply(200, '<requests><request id="1"><employee id="1">Jon Doe</employee><status lastChanged="2011-08-14" lastChangedByUserId="1">approved</status><start>2001-01-01</start><end>2001-01-06</end><created>2011-08-13</created><type id="1">Vacation</type><amount unit="days">5</amount><notes><note from="employee">Relaxing in the country for a few days.</note><note from="manager">Have fun!</note></notes><dates> <!-- This element may not be available for all requests --><date ymd="2001-01-01" amount="1"/><date ymd="2001-01-02" amount="1"/><date ymd="2001-01-03" amount="1"/><!-- dates with a 0 amount may not be included in the results. Included here for clarity --><date ymd="2001-01-04" amount="0"/> <date ymd="2001-01-05" amount="1"/><date ymd="2001-01-06" amount="1"/></dates></request></requests>')
+                .put('/api/gateway.php/test/v1/employees/1/time_off/request/', '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n<request>\n  <status>approved</status>\n  <start>2011-10-01</start>\n  <end>2011-10-02</end>\n  <timeOffTypeId>1</timeOffTypeId>\n  <amount>12</amount>\n  <previousRequest>10</previousRequest>\n  <notes>\n    <note from="employee">Having wisdom teeth removed</note>\n    <note from="manager">Get well soon</note>\n  </notes>\n  <dates>\n    <date amount="8" ymd="2011-10-01"/>\n    <date amount="4" ymd="2011-10-02"/>\n  </dates>\n</request>')
+                .reply(201)
+                .put('/api/gateway.php/test/v1/time_off/requests/10/status/', '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n<request>\n  <status>approved</status>\n  <note>Have fun!</note>\n</request>')
+                .reply(201)
         })
+
 
         test('We should get a list of time off requests with no supplied arguments', function (done) {
 
             bamboo.requests(function (err, resp) {
                 if (err){ return done(err) }
                 assert(resp instanceof Array)
-
+                assert.equal(resp[0].id, 1)
+                assert.equal(resp[0].employeeId, 1)
+                assert.equal(resp[0].employeeName, 'Jon Doe')
+                assert.equal(resp[0].status, 'approved')
+                assert.equal(resp[0].statusLastChanged, '2011-08-14')
+                assert.equal(resp[0].statusLastChangedByUserId, 1)
+                assert.equal(resp[0].start, '2001-01-01')
+                assert.equal(resp[0].end, '2001-01-06')
+                assert.equal(resp[0].created, '2011-08-13')
+                assert.equal(resp[0].type, 'Vacation')
+                assert.equal(resp[0].typeId, 1)
+                assert.equal(resp[0].amount, 5)
+                assert.equal(resp[0].amountUnit, 'days')
+                assert.deepEqual(resp[0].notes, [{
+                    from: 'employee',
+                    note: 'Relaxing in the country for a few days.'
+                }, {
+                    from: 'manager',
+                note: 'Have fun!'
+                }])
+                assert.deepEqual(resp[0].dates.slice(0, 2), [{
+                    date: '2001-01-01',
+                    amount: 1
+                }, {
+                    date: '2001-01-02',
+                    amount: 1
+                }])
                 done()
             })
         })
@@ -250,6 +282,38 @@ suite('BambooHR', function () {
 
                 done()
             })
+        })
+
+        test('We should be able to add a time off request', function (done) {
+            bamboo.employee(1).requestTimeOff({
+                status: 'approved',
+                start: '2011-10-01',
+                end: new Date('2011/10/02'),
+                timeOffTypeId: 1,
+                amount: 12,
+                notes: [{
+                    from: 'employee',
+                    note: 'Having wisdom teeth removed'
+                }, {
+                    from: 'manager',
+                    note: 'Get well soon'
+                }],
+                dates: [{
+                    date: '2011-10-01',
+                    amount: 8
+                }, {
+                    date: '2011-10-02',
+                    amount: 4
+                }],
+                previousRequest: 10
+            }, done)
+        })
+
+        test('We should be able to change a time off request status', function (done) {
+            bamboo.timeOffRequest(10).changeStatus({
+                status: 'approved',
+                note: 'Have fun!'
+            }, done)
         })
 
         suiteTeardown(function() {

--- a/test/test.js
+++ b/test/test.js
@@ -1,4 +1,4 @@
-var BambooHR = require('./../index')
+var BambooHR = require('../lib/index')
 
 var nock = require('nock')
 nock.disableNetConnect();


### PR DESCRIPTION
Fixes #4

You can see the exact changes. I tried to follow the same style as the project as much as possible. This breaks compatibility because `BambooHR::requests` now returns an array of`TimeOffRequest` class instances instead of the old xml parsed response. If that bothers you, I could bring back the old method and have the new method only as `BambooHR::timeOffRequests`(now it's both of them). If that doesn't bother you, just publish a new semver major version.