### PR TITLE
Handle empty Time Off requests

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -109,11 +109,11 @@ BambooHR.prototype.timeOffRequests = BambooHR.prototype.requests = function () {
         if (err) { return callback(err, response) }
         var requests = response.requests.request
 
-        var list = requests.map(function (object) {
+        var list = requests? requests.map(function (object) {
             var request = new TimeOffRequest(self, object.$.id)
             request.__parse_fields(object)
             return request
-        })
+        }) : []
 
         return callback(null, list)
     })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "node-bamboohr",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "description": "Node.js wrapper around the bamboohr.com API",
     "keywords": [
         "bamboohr"

--- a/test/test.js
+++ b/test/test.js
@@ -236,6 +236,8 @@ suite('BambooHR', function () {
                 .reply(201)
                 .put('/api/gateway.php/test/v1/time_off/requests/10/status/', '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n<request>\n  <status>approved</status>\n  <note>Have fun!</note>\n</request>')
                 .reply(201)
+                .get('/api/gateway.php/test/v1/time_off/requests/?start=2011-12-31&end=2011-12-31')
+                .reply(200, '<requests></requests>')
         })
 
 
@@ -279,6 +281,15 @@ suite('BambooHR', function () {
             bamboo.requests({start: '2011-09-01', end: '2011-09-11', type: 1, status: 'approved'}, function (err, resp) {
                 if (err){ return done(err) }
                 assert(resp instanceof Array)
+
+                done()
+            })
+        })
+
+        test('We should not throw an error on empty results', function (done) {
+            bamboo.requests({start: '2011-12-31', end: '2011-12-31'}, function (err, resp) {
+                if (err){ return done(err) }
+                assert.deepEqual(resp, [])
 
                 done()
             })


### PR DESCRIPTION
When the response of `bamboohr.timeOffRequests` contains no results an uncatchable TypeError is thrown.  This PR returns an empty array instead.

```
Uncaught TypeError: Cannot read property 'map' of undefined
      at node_modules/node-bamboohr/lib/index.js:112:28
      at Parser.<anonymous> (node_modules/xml2js/lib/xml2js.js:489:18)
      at Object.onclosetag (node_modules/xml2js/lib/xml2js.js:447:26)
      at emit (node_modules/sax/lib/sax.js:640:35)
      at emitNode (node_modules/sax/lib/sax.js:645:5)
      at closeTag (node_modules/sax/lib/sax.js:905:7)
      at Object.write (node_modules/sax/lib/sax.js:1306:13)
      at Parser.exports.Parser.Parser.parseString (node_modules/xml2js/lib/xml2js.js:508:31)
      at Parser.parseString (node_modules/xml2js/lib/xml2js.js:7:59)
      at Object.exports.parseString (node_modules/xml2js/lib/xml2js.js:540:19)
      at Request._callback (node_modules/node-bamboohr/lib/index.js:49:24)
      at Request.self.callback (node_modules/request/request.js:187:22)
      at Request.<anonymous> (node_modules/request/request.js:1044:10)
      at IncomingMessage.<anonymous> (node_modules/request/request.js:965:12)
      at endReadableNT (_stream_readable.js:913:12)
      at _combinedTickCallback (internal/process/next_tick.js:74:11)
      at process._tickCallback (internal/process/next_tick.js:98:9)
```